### PR TITLE
Updated the MySQL query to account for users who don't yet exist in the table

### DIFF
--- a/pos_sv.lua
+++ b/pos_sv.lua
@@ -8,7 +8,7 @@ RegisterServerEvent('es:coords')
 AddEventHandler('es:coords', function(x, y, z)
 	if(Users[source])then
 		Users[source]:setCoords(x, y, z)
-                MySQL:executeQuery("UPDATE user_position SET x_pos='@x', y_pos = '@y', z_pos = '@z' WHERE identifier = '@username'",{['@usersame'] = Users[source], ['@x'] = x, ['@y'] = y, ['@z'] = z})
+                MySQL:executeQuery("INSERT INTO user_position (identifier,x_pos,y_pos,z_pos) VALUES ('@username','@x','@y','@z') ON DUPLICATE KEY UPDATE x_pos='@x', y_pos='@y', z_pos='@z';",{['@usersame'] = Users[source], ['@x'] = x, ['@y'] = y, ['@z'] = z})
                 end)
 
 	end


### PR DESCRIPTION
If a user doesn't exist in the table, it's never going to be found in the where clause. This inserts the coordinates into the table, while checking to see if there's a duplicate value in the identifier column.

Note: This will require you to set your identifier column to a primary or unique key.